### PR TITLE
Improve RL training with episodes

### DIFF
--- a/car.js
+++ b/car.js
@@ -28,6 +28,16 @@ class Car {
 
         this.controls = new Controls(controlType)
     }
+    reset(x, y) {
+        this.x = x
+        this.y = y
+        this.speed = 0
+        this.angle = 0
+        this.damaged = false
+        this.lastState = null
+        this.lastAction = null
+    }
+
     update(roadBorders, traffic) {
         if (!this.damaged) {
             if (this.sensor) {
@@ -35,7 +45,10 @@ class Car {
             }
 
             if (this.useBrain) {
-                const state = this.brain.getState(this.sensor.readings)
+                const state = this.brain.getState(
+                    this.sensor.readings,
+                    this.angle
+                )
                 const action = this.brain.chooseAction(state)
                 this.#applyAction(action)
                 this.lastState = state
@@ -51,14 +64,22 @@ class Car {
             }
 
             if (this.useBrain && this.lastState && this.lastAction) {
-                const nextState = this.brain.getState(this.sensor.readings)
-                const reward = this.damaged ? -1 : 0.1
-                this.brain.update(this.lastState, this.lastAction, reward, nextState)
+                const nextState = this.brain.getState(
+                    this.sensor.readings,
+                    this.angle
+                )
+                let reward = this.damaged ? -1 : 0.1
+                reward += this.speed > 0 ? 0.1 : -0.05
+                reward -= Math.abs(this.angle) * 0.1
+                this.brain.update(
+                    this.lastState,
+                    this.lastAction,
+                    reward,
+                    nextState
+                )
             }
         } else {
-            setTimeout(() => {
-                window.location.reload()
-            }, 1000)
+            // training loop will reset the car
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
         <button id="startBtn">Start RL</button>
         <p>Click the button to train the car using reinforcement learning.</p>
         <div id="qValues"></div>
+        <div id="episodeInfo"></div>
     </div>
     <canvas id="carCanvas"></canvas>
     <canvas id="networkCanvas"></canvas>

--- a/main.js
+++ b/main.js
@@ -9,29 +9,39 @@ const networkCtx = networkCanvas.getContext('2d')
 
 const road = new Road(carCanvas.width / 2, carCanvas.width * 0.9)
 const car = new Car(road.getLaneCenter(1), 100, 30, 50, 'AI')
-const traffic = [
-    new Car(road.getLaneCenter(1), -300, 30, 40, 'DUMMY', 2),
-    new Car(road.getLaneCenter(1), -400, 80, 40, 'DUMMY', 2),
-]
 
-for (let i = 0; i < 50; i++) {
-    let newy = Math.random() * 5000 - 5000
-    let newlane = Math.floor(Math.random() * 5)
-    let maxspeed = Math.random() * 2
-    let newcar = new Car(
-        road.getLaneCenter(newlane),
-        newy,
-        30,
-        50,
-        'DUMMY',
-        maxspeed
-    )
-    traffic.push(newcar)
+function createTraffic() {
+    const t = [
+        new Car(road.getLaneCenter(1), -300, 30, 40, 'DUMMY', 2),
+        new Car(road.getLaneCenter(1), -400, 80, 40, 'DUMMY', 2),
+    ]
+
+    for (let i = 0; i < 50; i++) {
+        const newy = Math.random() * 5000 - 5000
+        const newlane = Math.floor(Math.random() * 5)
+        const maxspeed = Math.random() * 2
+        const newcar = new Car(
+            road.getLaneCenter(newlane),
+            newy,
+            30,
+            50,
+            'DUMMY',
+            maxspeed
+        )
+        t.push(newcar)
+    }
+    return t
 }
 
+let traffic = createTraffic()
+
 const qDiv = document.getElementById('qValues')
+const episodeDiv = document.getElementById('episodeInfo')
 const startBtn = document.getElementById('startBtn')
 let running = false
+let frame = 0
+let episode = 0
+const MAX_FRAMES = 1000
 startBtn.onclick = () => {
     if (!running) {
         running = true
@@ -39,7 +49,16 @@ startBtn.onclick = () => {
     }
 }
 
+function resetEpisode() {
+    traffic = createTraffic()
+    car.reset(road.getLaneCenter(1), 100)
+    car.brain.endEpisode()
+    frame = 0
+    episode++
+}
+
 function animate() {
+    frame++
     for (let i = 0; i < traffic.length; i++) {
         traffic[i].update(road.borders, [])
     }
@@ -58,11 +77,16 @@ function animate() {
     car.draw(carCtx, 'green')
 
     if (car.brain) {
-        const state = car.brain.getState(car.sensor.readings)
+        const state = car.brain.getState(car.sensor.readings, car.angle)
         const q = car.brain.qTable[state] || {}
         qDiv.textContent = Object.entries(q)
             .map(([a, v]) => `${a}: ${v.toFixed(2)}`)
             .join(' | ')
+        episodeDiv.textContent = `Episode: ${episode}  Epsilon: ${car.brain.epsilon.toFixed(2)}`
+    }
+
+    if (car.damaged || frame >= MAX_FRAMES) {
+        resetEpisode()
     }
 
     requestAnimationFrame(animate)

--- a/rl.js
+++ b/rl.js
@@ -4,14 +4,17 @@ class RLBrain {
         this.actions = actions
         this.alpha = 0.1
         this.gamma = 0.95
-        this.epsilon = 0.1
+        this.epsilon = 1
+        this.minEpsilon = 0.05
+        this.epsilonDecay = 0.995
     }
 
-    getState(sensorReadings) {
-        if (!sensorReadings) return 'null'
-        return sensorReadings
-            .map((s) => (s && s.offset < 0.5 ? 1 : 0))
-            .join('')
+    getState(sensorReadings, angle) {
+        const s = sensorReadings
+            ? sensorReadings.map((r) => (r && r.offset < 0.5 ? 1 : 0)).join('')
+            : 'null'
+        const bucket = Math.round(angle / (Math.PI / 4)) + 4
+        return `${s}_${bucket}`
     }
 
     chooseAction(state) {
@@ -36,11 +39,16 @@ class RLBrain {
         if (!this.qTable[state][action]) this.qTable[state][action] = 0
 
         const nextQ = this.qTable[nextState] || {}
-        const nextMax = Math.max(
-            ...this.actions.map((a) => nextQ[a] || 0)
-        )
+        const nextMax = Math.max(...this.actions.map((a) => nextQ[a] || 0))
         this.qTable[state][action] =
             (1 - this.alpha) * this.qTable[state][action] +
             this.alpha * (reward + this.gamma * nextMax)
+    }
+
+    endEpisode() {
+        this.epsilon = Math.max(
+            this.minEpsilon,
+            this.epsilon * this.epsilonDecay
+        )
     }
 }


### PR DESCRIPTION
## Summary
- enhance `RLBrain` with orientation-based state representation, epsilon decay, and episode end handler
- allow `Car` to reset and use improved reward function
- manage episodes in `main.js` with a new `resetEpisode` helper
- display episode and epsilon info in `index.html`

## Testing
- `npx prettier -w *.js *.html *.css` *(fails: unexpected characters in some files)*

------
https://chatgpt.com/codex/tasks/task_e_687bac13fee0832dae1512ce680d72ff