### PR TITLE
Use ray intersections in RL control

### DIFF
--- a/car.js
+++ b/car.js
@@ -21,7 +21,11 @@ class Car {
         }
 
         if (this.useBrain) {
-            this.brain = new RLBrain(['forward', 'left', 'right', 'backward'])
+            const featureCount = this.sensor.rayCount + 3
+            this.brain = new RLBrain(
+                ['forward', 'left', 'right', 'backward'],
+                featureCount
+            )
             this.lastState = null
             this.lastAction = null
         }
@@ -69,7 +73,15 @@ class Car {
                     this.angle
                 )
                 let reward = this.damaged ? -1 : 0.1
-                reward += this.speed > 0 ? 0.1 : -0.05
+                if (this.sensor && this.sensor.readings.length > 0) {
+                    const avgDist =
+                        this.sensor.readings.reduce(
+                            (sum, r) => sum + (r ? 1 - r.offset : 1),
+                            0
+                        ) / this.sensor.readings.length
+                    reward += avgDist * 0.1
+                }
+                reward += (this.speed / this.maxSpeed) * 0.2
                 reward -= Math.abs(this.angle) * 0.1
                 this.brain.update(
                     this.lastState,

--- a/rl.js
+++ b/rl.js
@@ -1,31 +1,49 @@
 class RLBrain {
-    constructor(actions) {
-        this.qTable = {}
+    constructor(actions, featureCount) {
         this.actions = actions
-        this.alpha = 0.1
+        this.alpha = 0.05
         this.gamma = 0.95
         this.epsilon = 1
         this.minEpsilon = 0.05
         this.epsilonDecay = 0.995
+        this.featureCount = featureCount
+        this.weights = {}
+        for (const a of actions) {
+            this.weights[a] = new Array(featureCount)
+                .fill(0)
+                .map(() => Math.random() * 0.1 - 0.05)
+        }
     }
 
     getState(sensorReadings, angle) {
-        const s = sensorReadings
-            ? sensorReadings.map((r) => (r && r.offset < 0.5 ? 1 : 0)).join('')
-            : 'null'
-        const bucket = Math.round(angle / (Math.PI / 4)) + 4
-        return `${s}_${bucket}`
+        const features = []
+        if (sensorReadings) {
+            for (const r of sensorReadings) {
+                features.push(r ? 1 - r.offset : 1)
+            }
+        }
+        features.push(Math.sin(angle))
+        features.push(Math.cos(angle))
+        features.push(1) // bias
+        return features
+    }
+
+    #dot(w, x) {
+        let sum = 0
+        for (let i = 0; i < w.length; i++) {
+            sum += w[i] * x[i]
+        }
+        return sum
     }
 
     chooseAction(state) {
-        if (Math.random() < this.epsilon || !this.qTable[state]) {
+        if (Math.random() < this.epsilon) {
             return this.actions[Math.floor(Math.random() * this.actions.length)]
         }
-        const qvals = this.qTable[state]
         let best = this.actions[0]
-        let bestVal = qvals[best] || 0
+        let bestVal = this.#dot(this.weights[best], state)
         for (const a of this.actions) {
-            const val = qvals[a] || 0
+            const val = this.#dot(this.weights[a], state)
             if (val > bestVal) {
                 bestVal = val
                 best = a
@@ -35,14 +53,17 @@ class RLBrain {
     }
 
     update(state, action, reward, nextState) {
-        if (!this.qTable[state]) this.qTable[state] = {}
-        if (!this.qTable[state][action]) this.qTable[state][action] = 0
-
-        const nextQ = this.qTable[nextState] || {}
-        const nextMax = Math.max(...this.actions.map((a) => nextQ[a] || 0))
-        this.qTable[state][action] =
-            (1 - this.alpha) * this.qTable[state][action] +
-            this.alpha * (reward + this.gamma * nextMax)
+        const currentQ = this.#dot(this.weights[action], state)
+        let nextQ = this.#dot(this.weights[this.actions[0]], nextState)
+        for (const a of this.actions) {
+            const val = this.#dot(this.weights[a], nextState)
+            if (val > nextQ) nextQ = val
+        }
+        const target = reward + this.gamma * nextQ
+        const error = target - currentQ
+        for (let i = 0; i < this.featureCount; i++) {
+            this.weights[action][i] += this.alpha * error * state[i]
+        }
     }
 
     endEpisode() {


### PR DESCRIPTION
## Summary
- upgrade `RLBrain` to learn using continuous ray distance features
- adjust `Car` to initialize RL with proper feature count
- update reward shaping to incorporate average ray distance and speed

## Testing
- `node -e "require('./car.js'); require('./rl.js')"`

------
https://chatgpt.com/codex/tasks/task_e_687c7e9453ac832d98bd08fdbf5d8dc1